### PR TITLE
Automatically change light vs dark mode in Cardinal

### DIFF
--- a/src/plugin.hpp
+++ b/src/plugin.hpp
@@ -121,7 +121,11 @@ struct RebelTechModuleWidget : ModuleWidget {
 template <class M>
 void updateComponentsForTheme(M* module, RebelTechModuleWidget* moduleWidget, ModuleTheme& lastPanelTheme) {
 
+#ifdef USING_CARDINAL_NOT_RACK
+	ModuleTheme currentTheme = settings::darkMode ? DARK_THEME : LIGHT_THEME;
+#else
 	ModuleTheme currentTheme = module ? module->theme : loadDefaultTheme();
+#endif
 
 	const bool redrawRequired = moduleWidget && lastPanelTheme != currentTheme;
 	const bool browserView = !module; 	// nullptr for module implies we're in browser view


### PR DESCRIPTION
Simple enough change, allows to use Cardinal's view -> dark mode menu option to switch between light and dark mode on RebelTech panels.
Protected by a compiler macro, so behaviour for regular VCV Rack builds remains unchanged.
