### PR TITLE
Update for Cardinal specific behaviour

### DIFF
--- a/src/plugin.hpp
+++ b/src/plugin.hpp
@@ -122,7 +122,7 @@ template <class M>
 void updateComponentsForTheme(M* module, RebelTechModuleWidget* moduleWidget, ModuleTheme& lastPanelTheme) {
 
 #ifdef USING_CARDINAL_NOT_RACK
-	ModuleTheme currentTheme = settings::darkMode ? DARK_THEME : LIGHT_THEME;
+	ModuleTheme currentTheme = settings::preferDarkPanels ? DARK_THEME : LIGHT_THEME;
 #else
 	ModuleTheme currentTheme = module ? module->theme : loadDefaultTheme();
 #endif


### PR DESCRIPTION
Cardinal has changed to stop using its custom `settings::darkMode` property, with now using `settings::preferDarkPanels` from VCV Rack.